### PR TITLE
Fixed bypassing expire after & access code due to predictable CDN downloads

### DIFF
--- a/backend/paaster/app/controllers/paste.py
+++ b/backend/paaster/app/controllers/paste.py
@@ -19,8 +19,8 @@ async def create_paste(request: Request, iv: str) -> PasteCreatedModel:
         raise HTTPException(detail="IV too large", status_code=400)
 
     # Shorter then Mongo IDs
-    paste_id = nanoid.generate(size=21)
-    file_key = format_file_path(paste_id)
+    download_id = token_urlsafe(32)
+    file_key = format_file_path(download_id)
     chunk_buffer = b""
 
     total_size = 0
@@ -78,8 +78,9 @@ async def create_paste(request: Request, iv: str) -> PasteCreatedModel:
     owner_secret = token_urlsafe(32)
 
     paste = {
-        "_id": paste_id,
+        "_id": nanoid.generate(size=21),
         "iv": iv,
+        "download_id": download_id,
         "created": datetime.now(),
         "expires_in_hours": None,
         "access_code": None,

--- a/backend/paaster/app/helpers/s3.py
+++ b/backend/paaster/app/helpers/s3.py
@@ -4,8 +4,8 @@ from aiobotocore.session import get_session
 from app.env import SETTINGS
 
 
-def format_file_path(paste_id: str) -> str:
-    return path.join(SETTINGS.s3.folder, f"{paste_id}.bin")
+def format_file_path(download_id: str) -> str:
+    return path.join(SETTINGS.s3.folder, f"{download_id}.bin")
 
 
 def s3_create_client():


### PR DESCRIPTION
Users could bypass expire after or access codes, by downloading the encrypted paste directly from the CDN & decrypting it with a custom tool using the provided encryption key in the URL.

This was possible due to pastes having a predictable CDN link e.g. `https://cdn-provider.invalid/pastes/{pasteId}.bin`

This PR introduces download IDs, meaning someone trying to access a paste 1st must be able to retrieve the download ID.